### PR TITLE
fix(api): add default to BOMItem.state to fix code generation 422

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -107,7 +107,7 @@ class StockItem(BaseModel):
 class BOMItem(BaseModel):
     component_name: str
     quantity_required: int
-    state: str  # available | partial | missing | incompatible
+    state: str = "available"  # available | partial | missing | incompatible
     available_quantity: int = 0
     alternatives: list[str] = []
     notes: str | None = None

--- a/src/test/CodeResources.test.tsx
+++ b/src/test/CodeResources.test.tsx
@@ -104,6 +104,16 @@ describe('CodeResources — Errores', () => {
       expect(screen.getByText(/oficina sin teléfono/i)).toBeInTheDocument()
     })
   })
+
+  it('muestra mensaje divertido en error 422', async () => {
+    const { generateCode } = await import('../lib/api')
+    vi.mocked(generateCode).mockRejectedValueOnce(new Error('API 422: validation error'))
+    render(<CodeResources {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /✨ Generar/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/no nos estamos entendiendo/i)).toBeInTheDocument()
+    })
+  })
 })
 
 describe('CodeResources — Lista y versiones', () => {


### PR DESCRIPTION
The /ai/code/generate endpoint was returning 422 because the frontend sends BOM items without the state field, which Pydantic required. The endpoint never uses state in its prompt — only component_name and quantity_required. Adding a default fixes the validation without breaking endpoints that do send state (discover, plan).

Closes jigmeshelri/iot-assistant#4