### PR TITLE
fix(islands): LocationPicker shows updated name after selection

### DIFF
--- a/src/components/islands/LocationPicker.tsx
+++ b/src/components/islands/LocationPicker.tsx
@@ -53,7 +53,7 @@ export default function LocationPicker({ value, onChange, locationName }: Props)
   }, [open])
 
   const selectedName = value
-    ? locationName ?? locations?.find(l => l.id === value)?.name ?? 'Sin ubicación'
+    ? locations?.find(l => l.id === value)?.name ?? locationName ?? 'Sin ubicación'
     : 'Sin ubicación'
 
   const tree = locations ? buildTree(locations) : null


### PR DESCRIPTION
The locationName prop (static, from server) had priority over the dynamic lookup from fetched locations. When user selected a different location, the old name kept showing until save+reload. Fix: prioritize find() over the prop — prop is now only a fallback while locations load.