### PR TITLE
fix(inventory): show edit form directly on desktop detail view (#20)

### DIFF
--- a/src/components/islands/InventoryDetail.tsx
+++ b/src/components/islands/InventoryDetail.tsx
@@ -21,6 +21,7 @@ interface Props {
   locationId: string | null
   locationName: string | null
   locationQrCode: string | null
+  initialEditing?: boolean
 }
 
 export default function InventoryDetail({
@@ -37,8 +38,9 @@ export default function InventoryDetail({
   notes,
   locationId,
   locationName,
+  initialEditing = false,
 }: Props) {
-  const [editing, setEditing] = useState(false)
+  const [editing, setEditing] = useState(initialEditing)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/src/pages/inventory/[id].astro
+++ b/src/pages/inventory/[id].astro
@@ -272,6 +272,7 @@ const capBadgeColors: Record<string, string> = {
         locationId={item.location?.id ?? null}
         locationName={item.location?.name ?? null}
         locationQrCode={item.location?.qr_code ?? null}
+        initialEditing={true}
         client:load
       />
     </div>


### PR DESCRIPTION
Add initialEditing prop to InventoryDetail so desktop renders the edit form immediately — the readonly info is already shown in the Astro cards above. Avoids duplicate content on the same page.