### PR TITLE
refactor(ComponentForm): extract useComponentForm hook (closes #28)

### DIFF
--- a/src/components/islands/ComponentForm.tsx
+++ b/src/components/islands/ComponentForm.tsx
@@ -1,85 +1,19 @@
-import { useState, useEffect } from 'react'
-import { categoryPrefix, nextAvailableSku } from '../../lib/skuUtils'
 import { CATEGORIES, PLATFORMS } from '../../lib/constants'
-import { addComponentToStock } from '../../lib/inventory'
+import { useComponentForm, type ComponentFormPrefill } from './hooks/useComponentForm'
 import ConnectivityEditor from './ConnectivityEditor'
 import SpecsEditor from './SpecsEditor'
 import LocationPicker from './LocationPicker'
 
 interface ComponentFormProps {
-  prefill?: {
-    sku?:              string
-    name?:             string
-    category?:         string
-    platform_family?:  string
-    technical_specs?:  Record<string, unknown>
-    datasheet_url?:    string
-    connectivity_caps?: Record<string, boolean>
-    location_id?: string
-  }
+  prefill?: ComponentFormPrefill
   imageFile?: File | null
 }
 
 export default function ComponentForm({ prefill, imageFile }: ComponentFormProps) {
-  const [name, setName] = useState(prefill?.name ?? '')
-  const [sku, setSku] = useState(prefill?.sku ?? '')
-  const [skuPlaceholder, setSkuPlaceholder] = useState('MCU-001')
-  const [skuConflict, setSkuConflict] = useState('')
-  const [category, setCategory] = useState(prefill?.category ?? CATEGORIES[0])
-  const [platform, setPlatform] = useState(prefill?.platform_family ?? '')
-  const [quantity, setQuantity] = useState(1)
-  const [caps, setCaps] = useState<Record<string, boolean>>(prefill?.connectivity_caps ?? {})
-  const [specs, setSpecs] = useState<Record<string, string>>(
-    Object.fromEntries(
-      Object.entries(prefill?.technical_specs ?? {}).map(([k, v]) => [k, String(v)])
-    )
-  )
-  const [locationId, setLocationId] = useState<string | null>(prefill?.location_id ?? null)
-  const [datasheetUrl, setDatasheetUrl] = useState(prefill?.datasheet_url ?? '')
-  const [notes, setNotes] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [success, setSuccess] = useState(false)
-  const [error, setError] = useState('')
+  const form = useComponentForm({ prefill, imageFile })
+  const { fields } = form
 
-  useEffect(() => {
-    const prefix = categoryPrefix(category)
-    nextAvailableSku(prefix).then(setSkuPlaceholder).catch(() => {})
-  }, [category])
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    setLoading(true)
-    setError('')
-    setSkuConflict('')
-    const effectiveSku = sku.trim() || skuPlaceholder
-    const { error: err } = await addComponentToStock({
-      sku: effectiveSku,
-      name,
-      category,
-      platform_family: platform || null,
-      technical_specs: specs,
-      datasheet_url: datasheetUrl || null,
-      connectivity_caps: caps,
-      quantity,
-      notes: notes || null,
-      location_id: locationId,
-      imageFile: imageFile ?? null,
-    })
-    setLoading(false)
-    if (err) {
-      if (err.type === 'sku_conflict') {
-        nextAvailableSku(categoryPrefix(category))
-          .then(suggestion => setSkuConflict(`Este código ya está en uso, sugerencia: ${suggestion}`))
-          .catch(() => {})
-      }
-      setError(err.message)
-      return
-    }
-    setSuccess(true)
-    setTimeout(() => { window.location.href = '/inventory' }, 1200)
-  }
-
-  if (success) {
+  if (form.success) {
     return (
       <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-6 text-center">
         <div className="text-3xl mb-2">✅</div>
@@ -89,7 +23,7 @@ export default function ComponentForm({ prefill, imageFile }: ComponentFormProps
   }
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white rounded-2xl shadow-sm border border-slate-100 p-5 space-y-4">
+    <form onSubmit={form.handleSubmit} className="bg-white rounded-2xl shadow-sm border border-slate-100 p-5 space-y-4">
       <h2 className="text-sm font-semibold text-slate-700">Datos del componente</h2>
 
       <div>
@@ -97,25 +31,25 @@ export default function ComponentForm({ prefill, imageFile }: ComponentFormProps
         <p className="text-xs text-slate-400 mb-1">Auto-generado si se deja vacío</p>
         <input
           id="sku"
-          value={sku}
-          onChange={e => { setSku(e.target.value); setSkuConflict('') }}
-          placeholder={skuPlaceholder}
+          value={fields.sku}
+          onChange={e => { form.setSku(e.target.value); form.setSkuConflict('') }}
+          placeholder={fields.skuPlaceholder}
           className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm font-mono focus:outline-none focus:ring-2 focus:ring-teal-400"
         />
-        {skuConflict && (
-          <p className="text-xs text-amber-600 mt-1">{skuConflict}</p>
+        {fields.skuConflict && (
+          <p className="text-xs text-amber-600 mt-1">{fields.skuConflict}</p>
         )}
       </div>
 
       <div>
         <label className="block text-xs font-medium text-slate-600 mb-1">Nombre *</label>
-        <input value={name} onChange={e => setName(e.target.value)} required placeholder="ESP32-C6 XIAO"
+        <input value={fields.name} onChange={e => form.setName(e.target.value)} required placeholder="ESP32-C6 XIAO"
           className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400" />
       </div>
 
       <div>
         <label className="block text-xs font-medium text-slate-600 mb-1">Categoría *</label>
-        <select value={category} onChange={e => setCategory(e.target.value)} required
+        <select value={fields.category} onChange={e => form.setCategory(e.target.value)} required
           className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
           {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
         </select>
@@ -123,22 +57,22 @@ export default function ComponentForm({ prefill, imageFile }: ComponentFormProps
 
       <div>
         <label className="block text-xs font-medium text-slate-600 mb-1">Plataforma</label>
-        <select value={platform} onChange={e => setPlatform(e.target.value)}
+        <select value={fields.platform} onChange={e => form.setPlatform(e.target.value)}
           className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
           <option value="">-- Sin especificar --</option>
           {PLATFORMS.map(p => <option key={p} value={p}>{p}</option>)}
         </select>
       </div>
 
-      <ConnectivityEditor value={caps} onChange={setCaps} />
+      <ConnectivityEditor value={fields.caps} onChange={form.setCaps} />
 
-      <SpecsEditor value={specs} onChange={setSpecs} />
+      <SpecsEditor value={fields.specs} onChange={form.setSpecs} />
 
       <div>
         <label className="block text-xs font-medium text-slate-600 mb-1">Datasheet URL</label>
         <input
-          value={datasheetUrl}
-          onChange={e => setDatasheetUrl(e.target.value)}
+          value={fields.datasheetUrl}
+          onChange={e => form.setDatasheetUrl(e.target.value)}
           placeholder="https://..."
           type="url"
           className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400"
@@ -147,26 +81,26 @@ export default function ComponentForm({ prefill, imageFile }: ComponentFormProps
 
       <div>
         <label className="block text-xs font-medium text-slate-600 mb-1">Cantidad *</label>
-        <input type="number" min={1} value={quantity} onChange={e => setQuantity(+e.target.value)} required
+        <input type="number" min={1} value={fields.quantity} onChange={e => form.setQuantity(+e.target.value)} required
           className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-400" />
       </div>
 
       <div>
         <label className="block text-xs font-medium text-slate-600 mb-1">Ubicación</label>
-        <LocationPicker value={locationId} onChange={setLocationId} />
+        <LocationPicker value={fields.locationId} onChange={form.setLocationId} />
       </div>
 
       <div>
         <label className="block text-xs font-medium text-slate-600 mb-1">Notas</label>
-        <textarea value={notes} onChange={e => setNotes(e.target.value)} rows={2} placeholder="Observaciones opcionales..."
+        <textarea value={fields.notes} onChange={e => form.setNotes(e.target.value)} rows={2} placeholder="Observaciones opcionales..."
           className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm resize-none focus:outline-none focus:ring-2 focus:ring-teal-400" />
       </div>
 
-      {error && <p className="text-xs text-red-500">{error}</p>}
+      {form.error && <p className="text-xs text-red-500">{form.error}</p>}
 
-      <button type="submit" disabled={loading}
+      <button type="submit" disabled={form.loading}
         className="w-full py-3 bg-teal-500 text-white rounded-xl font-medium text-sm hover:bg-teal-600 active:scale-95 transition-all disabled:opacity-50">
-        {loading ? 'Guardando...' : 'Guardar componente'}
+        {form.loading ? 'Guardando...' : 'Guardar componente'}
       </button>
     </form>
   )

--- a/src/components/islands/hooks/useComponentForm.ts
+++ b/src/components/islands/hooks/useComponentForm.ts
@@ -1,0 +1,120 @@
+import { useState, useEffect } from 'react'
+import type React from 'react'
+import { categoryPrefix, nextAvailableSku } from '../../../lib/skuUtils'
+import { CATEGORIES } from '../../../lib/constants'
+import { addComponentToStock } from '../../../lib/inventory'
+
+export interface ComponentFormPrefill {
+  sku?:               string
+  name?:              string
+  category?:          string
+  platform_family?:   string
+  technical_specs?:   Record<string, unknown>
+  datasheet_url?:     string
+  connectivity_caps?: Record<string, boolean>
+  location_id?:       string
+}
+
+export interface UseComponentFormInput {
+  prefill?: ComponentFormPrefill
+  imageFile?: File | null
+}
+
+export interface UseComponentFormResult {
+  fields: {
+    name: string
+    sku: string
+    skuPlaceholder: string
+    skuConflict: string
+    category: string
+    platform: string
+    quantity: number
+    caps: Record<string, boolean>
+    specs: Record<string, string>
+    locationId: string | null
+    datasheetUrl: string
+    notes: string
+  }
+  setName: (v: string) => void
+  setSku: (v: string) => void
+  setSkuConflict: (v: string) => void
+  setCategory: (v: string) => void
+  setPlatform: (v: string) => void
+  setQuantity: (v: number) => void
+  setCaps: (v: Record<string, boolean>) => void
+  setSpecs: (v: Record<string, string>) => void
+  setLocationId: (v: string | null) => void
+  setDatasheetUrl: (v: string) => void
+  setNotes: (v: string) => void
+  loading: boolean
+  success: boolean
+  error: string
+  handleSubmit: (e: React.FormEvent) => Promise<void>
+}
+
+export function useComponentForm({ prefill, imageFile }: UseComponentFormInput = {}): UseComponentFormResult {
+  const [name, setName] = useState(prefill?.name ?? '')
+  const [sku, setSku] = useState(prefill?.sku ?? '')
+  const [skuPlaceholder, setSkuPlaceholder] = useState('MCU-001')
+  const [skuConflict, setSkuConflict] = useState('')
+  const [category, setCategory] = useState(prefill?.category ?? CATEGORIES[0])
+  const [platform, setPlatform] = useState(prefill?.platform_family ?? '')
+  const [quantity, setQuantity] = useState(1)
+  const [caps, setCaps] = useState<Record<string, boolean>>(prefill?.connectivity_caps ?? {})
+  const [specs, setSpecs] = useState<Record<string, string>>(
+    Object.fromEntries(
+      Object.entries(prefill?.technical_specs ?? {}).map(([k, v]) => [k, String(v)])
+    )
+  )
+  const [locationId, setLocationId] = useState<string | null>(prefill?.location_id ?? null)
+  const [datasheetUrl, setDatasheetUrl] = useState(prefill?.datasheet_url ?? '')
+  const [notes, setNotes] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const prefix = categoryPrefix(category)
+    nextAvailableSku(prefix).then(setSkuPlaceholder).catch(() => {})
+  }, [category])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    setSkuConflict('')
+    const effectiveSku = sku.trim() || skuPlaceholder
+    const { error: err } = await addComponentToStock({
+      sku: effectiveSku,
+      name,
+      category,
+      platform_family: platform || null,
+      technical_specs: specs,
+      datasheet_url: datasheetUrl || null,
+      connectivity_caps: caps,
+      quantity,
+      notes: notes || null,
+      location_id: locationId,
+      imageFile: imageFile ?? null,
+    })
+    setLoading(false)
+    if (err) {
+      if (err.type === 'sku_conflict') {
+        nextAvailableSku(categoryPrefix(category))
+          .then(suggestion => setSkuConflict(`Este código ya está en uso, sugerencia: ${suggestion}`))
+          .catch(() => {})
+      }
+      setError(err.message)
+      return
+    }
+    setSuccess(true)
+    setTimeout(() => { window.location.href = '/inventory' }, 1200)
+  }
+
+  return {
+    fields: { name, sku, skuPlaceholder, skuConflict, category, platform, quantity, caps, specs, locationId, datasheetUrl, notes },
+    setName, setSku, setSkuConflict, setCategory, setPlatform, setQuantity, setCaps, setSpecs, setLocationId, setDatasheetUrl, setNotes,
+    loading, success, error,
+    handleSubmit,
+  }
+}

--- a/src/test/useComponentForm.test.ts
+++ b/src/test/useComponentForm.test.ts
@@ -1,0 +1,93 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { useComponentForm } from '../components/islands/hooks/useComponentForm'
+
+const mockAddComponentToStock = vi.fn().mockResolvedValue({ componentId: 'c1', error: null })
+const mockLike = vi.fn().mockResolvedValue({ data: [], error: null })
+
+vi.mock('../lib/inventory', () => ({
+  addComponentToStock: (...args: unknown[]) => mockAddComponentToStock(...args),
+}))
+
+vi.mock('../lib/supabase', () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } } }) },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({ like: mockLike })),
+    })),
+  }),
+}))
+
+Object.defineProperty(window, 'location', { writable: true, value: { href: '' } })
+
+describe('useComponentForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.location.href = ''
+    mockAddComponentToStock.mockResolvedValue({ componentId: 'c1', error: null })
+    mockLike.mockResolvedValue({ data: [], error: null })
+  })
+
+  it('initializes fields from prefill', () => {
+    const { result } = renderHook(() =>
+      useComponentForm({ prefill: { name: 'DHT22', category: 'Sensor' } }),
+    )
+    expect(result.current.fields.name).toBe('DHT22')
+    expect(result.current.fields.category).toBe('Sensor')
+  })
+
+  it('initializes with empty defaults when no prefill', () => {
+    const { result } = renderHook(() => useComponentForm())
+    expect(result.current.fields.name).toBe('')
+    expect(result.current.fields.sku).toBe('')
+    expect(result.current.fields.quantity).toBe(1)
+    expect(result.current.fields.locationId).toBeNull()
+  })
+
+  it('setters update fields', () => {
+    const { result } = renderHook(() => useComponentForm())
+    act(() => result.current.setName('foo'))
+    expect(result.current.fields.name).toBe('foo')
+  })
+
+  it('handleSubmit calls addComponentToStock with expected input shape', async () => {
+    const imageFile = new File(['x'], 'x.png', { type: 'image/png' })
+    const { result } = renderHook(() =>
+      useComponentForm({
+        prefill: { name: 'ESP32', category: 'Microcontrolador', platform_family: 'ESP32' },
+        imageFile,
+      }),
+    )
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: vi.fn() } as unknown as React.FormEvent)
+    })
+    expect(mockAddComponentToStock).toHaveBeenCalledOnce()
+    const [input] = mockAddComponentToStock.mock.calls[0]
+    expect(input).toMatchObject({
+      name: 'ESP32',
+      category: 'Microcontrolador',
+      platform_family: 'ESP32',
+      quantity: 1,
+      location_id: null,
+      imageFile,
+    })
+    expect(input).toHaveProperty('sku')
+  })
+
+  it('handleSubmit sets skuConflict on sku_conflict error', async () => {
+    mockAddComponentToStock.mockResolvedValueOnce({
+      componentId: null,
+      error: { type: 'sku_conflict', message: 'dup' },
+    })
+    const { result } = renderHook(() =>
+      useComponentForm({ prefill: { name: 'X', category: 'Sensor' } }),
+    )
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: vi.fn() } as unknown as React.FormEvent)
+    })
+    await waitFor(() => {
+      expect(result.current.fields.skuConflict.length).toBeGreaterThan(0)
+    })
+    expect(result.current.error).toBe('dup')
+  })
+})


### PR DESCRIPTION
## Summary

Closes the second half of #28: extracts the form state, side effects, and submit handler of \`ComponentForm\` into a custom hook \`useComponentForm\`. The island is now (mostly) presentation — JSX wired to \`form.fields\` and \`form.setX\`. SRP at the component level: the hook owns \"form behavior\", the island owns \"form rendering\".

## Commits

| Commit | Description |
|---|---|
| \`f4e6e41\` | \`feat(islands/hooks): add useComponentForm hook\` — new file with full implementation + 5 unit tests. Island still has its old code; nothing consumes the hook yet. |
| \`8b11019\` | \`refactor(ComponentForm): consume useComponentForm and remove duplicated state\` — deletes the duplicated state from the island, replaces with \`const form = useComponentForm(...)\`. |

The split is intentional: commit 1 introduces the abstraction without changing runtime behavior (cleanly revertible). Commit 2 is the actual swap. If commit 2 ever needs rollback, the diff is small and isolated.

## Numbers

| | Before | After |
|---|---|---|
| \`ComponentForm.tsx\` lines | 173 | **107** (-38%) |
| \`useComponentForm.ts\` lines | — | 120 (new) |
| Tests | 379 | **384** (+5 hook tests) |

The total LOC grew slightly because the hook adds boundary types and the consumer needs the mapping. That's expected and worth it: the hook is independently testable, the island has a single responsibility, and any future change to form behavior (validation, async submit, dirty tracking) lives in one place.

## What moved into the hook

- All \`useState\` calls (name, sku, category, platform, quantity, caps, specs, locationId, datasheetUrl, notes, loading, success, error, skuConflict, skuPlaceholder).
- The \`useEffect\` on \`[category]\` that fetches the next available SKU placeholder.
- The \`handleSubmit\` function, including:
  - Building the \`AddComponentInput\` object
  - Calling \`addComponentToStock\`
  - Handling the typed \`AddComponentError\` (the \`sku_conflict\` branch that suggests the next available SKU)
  - Navigating to \`/inventory\` on success via \`window.location.href\`
- The \`success\` early-return state.

## What stayed in the island

- The \`<form>\` JSX
- The success message (early return based on \`form.success\`)
- The \`SkuConflictHelper\` text rendering
- All Tailwind classes, field order, labels, placeholders — untouched

## Out of scope

- The \`window.location.href\` navigation stays inside the hook. Per the user's KISS guidance, an \`onSuccess\` callback prop would be scope creep.
- The hardcoded label text \`'ESP32-C6 XIAO'\` placeholder and other UI strings are unchanged.
- The pre-existing technical specs overflow bug on mobile is tracked in #30, NOT addressed here.

## Test plan

- [x] \`npx vitest run\` — 384/384 passing.
- [x] \`npx vitest run src/test/useComponentForm.test.ts\` — 5/5 passing (initial state from prefill, initial state without prefill, setters update fields, handleSubmit calls addComponentToStock, handleSubmit handles sku_conflict).
- [x] \`npx vitest run src/test/ComponentForm.test.tsx\` — 11/11 passing UNCHANGED (the public API of \`<ComponentForm>\` is identical, so existing integration tests didn't need touching).
- [ ] **Reviewer manual**: scan a component → form pre-fills → submit → navigates to /inventory. SKU conflict path: type a SKU that exists → submit → toast suggestion appears.

## Notes for the reviewer

- One small deviation from the spec: I added a \`setSkuConflict\` setter to the hook's public API. The SKU input's \`onChange\` clears the conflict message inline (\`onChange={e => { form.setSku(e.target.value); form.setSkuConflict('') }}\`), so the island needs that setter exposed. The alternative (clearing conflict inside \`setSku\`) would have changed existing behavior subtly. Kept the setter as-is.
- The hook test file uses \`renderHook\` from \`@testing-library/react\`. Standard pattern, no new deps.

## Follow-ups still in #28

#28 is fully closed by this PR. The latent bugs (memory leak + prefill sync) were closed in PR #29. The SRP split is closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)