### PR TITLE
docs(claude): sync project structure with reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,13 @@
 
 ## Stack
 
-Astro 6 + React 19 (Islands) + Tailwind 4 + Supabase (PostgreSQL + RLS) + Vitest + Playwright
+**Web app** (este repo, deploy a Vercel): Astro 6 + React 19 (Islands) + Tailwind 4 + Supabase (PostgreSQL + RLS) + Vitest + Playwright.
+
+**Servicio auxiliar `api/`** (deploy a Railway): servicio Python que expone el agente conversacional consumido desde la web app para responder preguntas sobre el inventario y los proyectos del usuario.
 
 ## Documentación Clave
 
-- `FUNCTIONAL_SPEC.md` — PRD con acceptance criteria (45 ACs, priorización MoSCoW)
+- `FUNCTIONAL_SPEC.md` — PRD con acceptance criteria (priorización MoSCoW)
 - `TECHNICAL_SPEC.md` — Schema de DB, arquitectura del sistema, stack completo
 - `supabase/schema.sql` — Source of truth del schema de base de datos
 
@@ -14,17 +16,24 @@ Astro 6 + React 19 (Islands) + Tailwind 4 + Supabase (PostgreSQL + RLS) + Vitest
 
 ```
 src/
-  components/islands/  → React islands (25 componentes interactivos)
-  components/ui/       → Astro components (5 componentes estáticos)
-  lib/                 → Lógica de negocio y acceso a datos (13 módulos)
-  pages/               → Rutas Astro (17 páginas)
-  test/                → Unit tests Vitest (39 archivos)
+  components/islands/  → React islands (interactivos, hidratados con client:*)
+  components/ui/       → Componentes Astro estáticos (sin JS por defecto)
+  lib/                 → Lógica de negocio y acceso a datos (abstracción sobre Supabase)
+  pages/               → Rutas Astro
+  layouts/             → Layouts Astro compartidos
+  styles/              → Tailwind v4 globals (@theme tokens)
+  test/                → Unit tests Vitest
+  middleware.ts        → Astro middleware (auth/session)
 e2e/
-  ui/                  → Playwright specs (29 archivos)
+  ui/                  → Playwright specs
   fixtures/            → Seed data para E2E (seeded-test.ts)
+  helpers/             → Helpers compartidos para specs
 supabase/
   schema.sql           → Schema de DB (source of truth)
   migrations/          → Migraciones SQL
+api/                   → Servicio Python (Railway) — agente conversacional
+mockups/               → Mockups del proyecto, publicados via GitHub Pages
+docs/                  → Proposals activos y archive de planes/specs completados
 ```
 
 ## TDD Estricto


### PR DESCRIPTION
## Summary

Sincroniza `CLAUDE.md` con el estado real del repo y limpia un directorio huérfano.

- **Stack**: aclara que es web app (Vercel) + servicio auxiliar `api/` en Python (Railway) que expone el agente conversacional
- **Estructura del proyecto**: agrega entradas faltantes (`layouts/`, `styles/`, `middleware.ts`, `api/`, `mockups/`, `docs/`, `e2e/helpers/`) y elimina conteos numéricos que se desactualizan rápido
- **Documentación clave**: quita el "(45 ACs)" obsoleto del `FUNCTIONAL_SPEC.md`
- **Cleanup**: elimina `tests/__file_snapshots__/build-from-skills-integration.test.ts.snap` huérfano (no había tests asociados que lo generaran)

## Contexto

El `CLAUDE.md` no reflejaba la realidad del repo: faltaba el servicio `api/` (Python en Railway), faltaban directorios reales (`layouts/`, `styles/`, `middleware.ts`, `mockups/`, `docs/`), y los conteos de archivos eran inaccurate. El snapshot huérfano venía de un test que ya no existe.

## Test plan

- [ ] El `CLAUDE.md` describe correctamente el stack actual y la estructura real del repo
- [ ] No quedan referencias al directorio `tests/` huérfano
- [ ] Verificar que `find . -name "tests" -type d -not -path "./node_modules/*"` no devuelve resultados